### PR TITLE
fix bug that caused avatars to get stuck when behaviour loop was set to "talk" during a walk cycle

### DIFF
--- a/src/frontend/GameObject.js
+++ b/src/frontend/GameObject.js
@@ -82,7 +82,7 @@ class GameObject {
         };
 
         // https://www.youtube.com/watch?v=e144CXGy2mc part 8
-        this.behaviourLoop = config.behaviourLoop || this.behaviours.idle;
+        this.behaviourLoop = config.behaviourLoop || this.behaviours[BEHAVIOUR.IDLE];
         this.behaviourLoopIndex = 0;
 
         // https://youtu.be/kfSTLrCoFxk?t=835

--- a/src/frontend/GameObject.js
+++ b/src/frontend/GameObject.js
@@ -1,5 +1,10 @@
 'use strict'
 
+const BEHAVIOUR = {
+    IDLE: "idle",
+    TALK: "talk",
+};
+
 class GameObject {
     constructor(config){
         // username
@@ -63,27 +68,31 @@ class GameObject {
         // default direction
         this.direction = "left";
 
-        this.idleBehaviour = [
-            { type: "walk", direction: "left"},
-            // could use small time value to have them run around chaotically!
-            { type: "stand", direction: "left", time: Math.random()*this.standTime},
-            { type: "walk", direction: "right"},
-            { type: "stand", direction: "right", time: Math.random()*this.standTime},
-        ];
-
+        this.behaviours = {
+            [BEHAVIOUR.IDLE]: [
+                { type: "walk", direction: "left"},
+                // could use small time value to have them run around chaotically!
+                { type: "stand", direction: "left", time: Math.random()*this.standTime},
+                { type: "walk", direction: "right"},
+                { type: "stand", direction: "right", time: Math.random()*this.standTime},
+            ],
+            [BEHAVIOUR.TALK]: [
+                { type: "talking" },
+            ],
+        };
 
         // https://www.youtube.com/watch?v=e144CXGy2mc part 8
-        this.behaviourLoop = config.behaviourLoop || [
-            { type: "walk", direction: "left"},
-            // could use small time value to have them run around chaotically!
-            { type: "stand", direction: "left", time: Math.random()*this.standTime},
-            { type: "walk", direction: "right"},
-            { type: "stand", direction: "right", time: Math.random()*this.standTime},
-        ]
+        this.behaviourLoop = config.behaviourLoop || this.behaviours.idle;
         this.behaviourLoopIndex = 0;
 
         // https://youtu.be/kfSTLrCoFxk?t=835
         this.retryTimeout = null;
+    }
+
+    changeBehaviour(behaviour) {
+        this.emitEvent("BehaviourLoopChanged");
+        this.behaviourLoop = this.behaviours[behaviour];
+        this.behaviourLoopIndex = 0;
     }
 
     // wait for what's going on first, any overarching cutsene event or whatever
@@ -176,6 +185,7 @@ class GameObject {
 
     // do my own behavior
     async doBehaviorEvent(overworld){
+        this.emitEvent("StartBehavior");
         
         // Don't execute this function if there's an overarching event happening
         // or if my behavior is empty

--- a/src/frontend/GameObject.js
+++ b/src/frontend/GameObject.js
@@ -185,7 +185,6 @@ class GameObject {
 
     // do my own behavior
     async doBehaviorEvent(overworld){
-        this.emitEvent("StartBehavior");
         
         // Don't execute this function if there's an overarching event happening
         // or if my behavior is empty

--- a/src/frontend/Overworld.js
+++ b/src/frontend/Overworld.js
@@ -51,13 +51,7 @@ class Overworld{
             
             // check if user wrote a message
             if(messagesObject[user]){
-                //console.log(this.userAvatars[user]);
-                // add new behavior loop
-                this.userAvatars[user].behaviourLoop = [
-                    { type: "talking" }
-                ];
-                this.userAvatars[user].behaviourLoopIndex = 0;
-                // this.userAvatars[user].mount(this);
+                this.userAvatars[user].changeBehaviour(BEHAVIOUR.TALK);
             }
         };
         for (let i = 0; i < emoteArray.length; i++) {

--- a/src/frontend/OverworldEvent.js
+++ b/src/frontend/OverworldEvent.js
@@ -25,13 +25,13 @@ class OverworldEvent{
         const completeHandler = e => {
             if(e.detail.whoName === this.event.who){
                 document.removeEventListener("AvatarStandingComplete", completeHandler);
+                document.removeEventListener("BehaviourLoopChanged", completeHandler);
                 resolve();
             }
         }
 
-        document.addEventListener("AvatarStandingComplete", completeHandler)
-
-
+        document.addEventListener("AvatarStandingComplete", completeHandler);
+        document.addEventListener("BehaviourLoopChanged", completeHandler);
     }
 
     walk(resolve){
@@ -51,12 +51,13 @@ class OverworldEvent{
         const completeHandler = e => {
             if(e.detail.whoName === this.event.who){
                 document.removeEventListener("AvatarWalkingComplete", completeHandler);
+                document.removeEventListener("BehaviourLoopChanged", completeHandler);
                 resolve();
             }
         }
 
         document.addEventListener("AvatarWalkingComplete", completeHandler)
-
+        document.addEventListener("BehaviourLoopChanged", completeHandler);
     }
 
     talking(resolve){
@@ -70,13 +71,13 @@ class OverworldEvent{
         })
         const completeHandler = e => {
             if(e.detail.whoName === this.event.who){
-                document.removeEventListener("AvatarBeginTalkingComplete", completeHandler);
+                document.removeEventListener("AvatarTalkingComplete", completeHandler);
+                document.removeEventListener("BehaviourLoopChanged", completeHandler);
                 resolve();
             }
         }
-        document.addEventListener("AvatarBeginTalkingComplete", completeHandler);
-
-
+        document.addEventListener("AvatarTalkingComplete", completeHandler);
+        document.addEventListener("BehaviourLoopChanged", completeHandler);
     }
 
 
@@ -97,12 +98,13 @@ class OverworldEvent{
         const completeHandler = e => {
             if(e.detail.whoName === this.event.who){
                 document.removeEventListener("EmoteAnimationComplete", completeHandler);
+                document.removeEventListener("BehaviourLoopChanged", completeHandler);
                 resolve();
             }
         }
 
-        document.addEventListener("EmoteAnimationComplete", completeHandler)
-
+        document.addEventListener("EmoteAnimationComplete", completeHandler);
+        document.addEventListener("BehaviourLoopChanged", completeHandler);
     }
 
     // kicks off event

--- a/src/frontend/Sprite.js
+++ b/src/frontend/Sprite.js
@@ -71,10 +71,8 @@ class Sprite {
                 this.currentAnimationFrame = 0;
             }
             else{
-                console.log(this.gameObject);
-                this.gameObject.emitEvent("AvatarBeginTalkingComplete");
-                this.gameObject.behaviourLoop = this.gameObject.idleBehaviour;
-                this.gameObject.behaviourLoopIndex = 0;
+                this.gameObject.emitEvent("AvatarTalkingComplete");
+                this.gameObject.changeBehaviour(BEHAVIOUR.IDLE);
                 this.currentAnimation = "idle";
                 this.currentAnimationFrame = 0;
             }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -21,6 +21,7 @@ const clearUsers = 'clearUsers';
 
 // = = = construction: users database in data/users = = =
 
+const USER_ALLOW_LIST = []
 const DATA_DIR = './data';
 const USER_DATA_DIR =  DATA_DIR + '/users';
 
@@ -34,8 +35,10 @@ function loadUsers() {
     const users = {};
     const files = fs.readdirSync(USER_DATA_DIR);
     for (const file of files) {
-        const user = JSON.parse(fs.readFileSync(`${USER_DATA_DIR}/${file}`));
-        users[user.name] = user;
+        const user = JSON.parse(fs.readFileSync(`${USER_DATA_DIR}/${file}`))
+        if (USER_ALLOW_LIST.length === 0 || USER_ALLOW_LIST.includes(user.name)) {
+            users[user.name] = user;
+        }
     };
     return users;
 };
@@ -107,6 +110,10 @@ client.on('message', (channel, tags, message, self) => {
     // it extracts what's in {} out of what's on the right
     const { username } = tags;
     
+    if (USER_ALLOW_LIST.length > 0 && !USER_ALLOW_LIST.includes(username)) {
+        return
+    }
+    
     const detectedCommand = message.match(/^!([a-z]+)($|\s.*)/)
 
     if (detectedCommand) {
@@ -151,7 +158,7 @@ client.on('message', (channel, tags, message, self) => {
         // first, save the user in the db if they weren't yet
         if (!(username in users)) {
             putUserIntoObject(users, tags);
-        } 
+        }
 
         // same, but for new users in current session aka current stream
         if (!(username in usersInThisSession)) {
@@ -232,5 +239,5 @@ app.get('/users', (req, res) => {
 
 // (: 
 app.listen(port, () => {
-    console.log(`Web-Avatars listening on port ${port}`)
+    console.log(`Web-Avatars listening on http://localhost:${port}`)
 })


### PR DESCRIPTION
When the behaviour was simply exchanged, the avatar `AvatarWalkingComplete` event was never emitted so the player got stuck forever.
Now an event is emitted whenever the behaviour is exchanged. All behaviours react to that event in addition to their respective completion event, so they do not get stuck anymore.